### PR TITLE
Transparency patch

### DIFF
--- a/rose-pine
+++ b/rose-pine
@@ -25,8 +25,8 @@ set notification-error-fg       "#555169"
 set notification-warning-bg     "#ebbcba"
 set notification-warning-fg     "#555169"
 
-set highlight-color             "#ebbcba"
-set highlight-active-color      "#eb6f92"
+set highlight-color             "rgba(0xeb, 0xbc, 0xba, 0.5)"
+set highlight-active-color      "rgba(0xeb, 0x6f, 0x92, 0.5)"
 
 set completion-bg               "#6e6a86"
 set completion-fg               "#ebbcba"

--- a/rose-pine-dawn
+++ b/rose-pine-dawn
@@ -25,8 +25,8 @@ set notification-error-fg       "#ea9d34"
 set notification-warning-bg     "#6e6a86"
 set notification-warning-fg     "#ea9d34"
 
-set highlight-color             "#b4637a"
-set highlight-active-color      "#d7827e"
+set highlight-color             "rgba(0xb4, 0x63, 0x7a, 0.5)"
+set highlight-active-color      "rgba(0xd7, 0x82, 0x7e, 0.5)"
 
 set completion-bg               "#6e6a86"
 set completion-fg               "#d7827e"

--- a/rose-pine-moon
+++ b/rose-pine-moon
@@ -25,8 +25,8 @@ set notification-error-fg       "#ea9a97"
 set notification-warning-bg     "#817c9c"
 set notification-warning-fg     "#f6c177"
 
-set highlight-color             "#3e8fb0"
-set highlight-active-color      "#9ccfd8"
+set highlight-color             "rgba(0x3e, 0x8f, 0xb0, 0.5)"
+set highlight-active-color      "rgba(0x9c, 0xcf, 0xd8, 0.5)"
 
 set completion-bg               "#817c9c"
 set completion-fg               "#9ccfd8"


### PR DESCRIPTION
Fix transparency issue for highlights

Use rgba to set transparency for highlights to (previous default) 0.5. 

As per [zathura 0.5.5](https://pwmt.org/news/zathura-0-5-5/index.html):
> Remove highlight-transparency setting. Set the alpha component of highlight-color, highlight-active-color and highlight-fg instead.